### PR TITLE
Update packaging tool to 4.0.1.1 to fix activity packaging for 3.0.x platforms

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="PropertyChanged.Fody" Version="4.1.0" />
     <PackageVersion Include="STG.RT.API" Version="4.0.1" />
     <PackageVersion Include="STG.RT.API.Signaling" Version="4.0.1" />
-    <PackageVersion Include="STG.Tools.ActivityPackaging" Version="4.0.1" />
+    <PackageVersion Include="STG.Tools.ActivityPackaging" Version="4.0.1.1" />
     <PackageVersion Include="Stelvio.Classification.ProjectService.Client" Version="4.4.3" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />


### PR DESCRIPTION
the tool in version 4.0.1 contained a bug that did not package the System.Data.Annotations.dll that does not exist on 3.0.6 or earlier platforms