### PR TITLE
Update packaging tool nuget to 4.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="PropertyChanged.Fody" Version="4.1.0" />
     <PackageVersion Include="STG.RT.API" Version="4.0.1" />
     <PackageVersion Include="STG.RT.API.Signaling" Version="4.0.1" />
-    <PackageVersion Include="STG.Tools.ActivityPackaging" Version="4.0.1.1" />
+    <PackageVersion Include="STG.Tools.ActivityPackaging" Version="4.1.0" />
     <PackageVersion Include="Stelvio.Classification.ProjectService.Client" Version="4.4.3" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />

--- a/README.md
+++ b/README.md
@@ -20,6 +20,39 @@ The solution Samples.sln provides the following samples corresponding folders:
 - [WebHeartbeatReporter](WebHeartbeatReporter/README.md) - sample for a Web client that provides heartbeat
 - [WorkItemSearchAndLock](WorkItemSearchAndLock/README.md) - sample tool that simulates multiple requests to lock a work item on the Platform
 
+## Activity Packaging How-to
+
+To create activity packages for the platform (*.stgpack), STG.ActivityPackaging.Packager.exe tool is used.
+The nuget package `STG.Tools.ActivityPackaging` is provided to partners and contains that tool.
+With the release of that packaging tool version **4.1.0**,
+we have separated it from the platform, so that only 1 packager version is required to package activities for any platform version.
+
+To use the tool, we recommend adding it to your SDK style build scripts as a PackageReference:
+
+```xml
+<Project DefaultTargets="release" Sdk="Microsoft.Build.NoTargets/3.3.0">
+  <ItemGroup>
+    <PackageReference Include="STG.Tools.ActivityPackaging" />
+  </ItemGroup>
+  <Target Name="_publish" AfterTargets="publish" DependsOnTargets="BuildActivity;package">
+  <Target Name="BuildActivity">
+    <!-- build/prep scripts -->
+  </Target>
+  <Target Name="package" DependsOnTargets="getversion">
+    <!-- Package the event driven sample activities -->
+    <Exec Command="$(PkgSTG_Tools_ActivityPackaging_Packager) -f &quot;.\SampleEventDrivenActivity\activityPackage.json&quot; -version $(FileVersion) $(PublishOutputDirectory)\DemoActivities\SampleEventDrivenActivity.stgpack" />
+  </Target>
+</Project>
+```
+
+The configuration for the activity's assemblies, name, etc., are contained in a json file like `activityPackage.json`.
+Creating a new activity package is then as easy as calling:
+
+```powershell
+msbuild /t:restore
+msbuild /t:publish
+```
+
 ## General Activity Entry Point Requirements
 
 An activity is not only executed by the platform's runtime, but also instantiated during activity registration.

--- a/all.proj
+++ b/all.proj
@@ -35,14 +35,18 @@
   </Target>
   <Target Name="package" DependsOnTargets="getversion">
     <PropertyGroup>
-      <stgPackagingToolExe>$(PkgSTG_Tools_ActivityPackaging)\tools\STG.ActivityPackaging.Packager.exe</stgPackagingToolExe>
+      <!-- The packaging tool provides the property $(PkgSTG_Tools_ActivityPackaging_Packager) since version 4.1.0:
+      $(PkgSTG_Tools_ActivityPackaging_Packager) runs via `dotnet <path> STG.ActivityPackaging.Packager.dll`.
+      $(PkgSTG_Tools_ActivityPackaging_PackagerExe) points to `$(PkgSTG_Tools_ActivityPackaging)\tools\STG.ActivityPackaging.Packager.exe` (beware of spaces in that path)
+      For older versions than 4.1.0, you have to define the path yourself -->
+      <!-- <stgPackagingToolExe>$(PkgSTG_Tools_ActivityPackaging)\tools\STG.ActivityPackaging.Packager.exe</stgPackagingToolExe> -->
     </PropertyGroup>
-    <!--Package the event driven sample activities-->
-    <Exec Command="&quot;$(stgPackagingToolExe)&quot; -f &quot;.\SampleEventDrivenActivity\activityPackage.json&quot; -version $(FileVersion) $(PublishOutputDirectory)\DemoActivities\SampleEventDrivenActivity.stgpack" />
-    <!--Package sample activities that show-case licensing as well as splitting/merging-->
-    <Exec Command="&quot;$(stgPackagingToolExe)&quot; -f &quot;.\SampleActivities\activityPackage.json&quot; -version $(FileVersion) $(PublishOutputDirectory)\DemoActivities\SampleActivities.stgpack" />
-    <!--Sample demonstrating how to package .NET Framework and .NET8 compatible activity packages-->
-    <Exec Command="&quot;$(stgPackagingToolExe)&quot; -f &quot;.\SampleActivities\backwardsCompatibility.json&quot; -version $(FileVersion) $(PublishOutputDirectory)\DemoActivities\BackwardsCompatibilitySample.stgpack" />
+    <!-- Package the event driven sample activities -->
+    <Exec Command="$(PkgSTG_Tools_ActivityPackaging_Packager) -f &quot;.\SampleEventDrivenActivity\activityPackage.json&quot; -version $(FileVersion) $(PublishOutputDirectory)\DemoActivities\SampleEventDrivenActivity.stgpack" />
+    <!-- Package sample activities that show-case licensing as well as splitting/merging -->
+    <Exec Command="$(PkgSTG_Tools_ActivityPackaging_Packager) -f &quot;.\SampleActivities\activityPackage.json&quot; -version $(FileVersion) $(PublishOutputDirectory)\DemoActivities\SampleActivities.stgpack" />
+    <!-- Sample demonstrating how to package .NET Framework and .NET8 compatible activity packages -->
+    <Exec Command="$(PkgSTG_Tools_ActivityPackaging_Packager) -f &quot;.\SampleActivities\backwardsCompatibility.json&quot; -version $(FileVersion) $(PublishOutputDirectory)\DemoActivities\BackwardsCompatibilitySample.stgpack" />
     <Copy SourceFiles=".\SampleActivities\Readme.md" DestinationFiles="$(PublishOutputDirectory)\DemoActivities\SampleActivities_Readme.md" />
     <Copy SourceFiles="@(Package-Tools-and-Websites)" DestinationFolder="$(PublishOutputDirectory)\DemoActivities\%(Package-Tools-and-Websites.Subfolder)\%(RecursiveDir)" />
   </Target>


### PR DESCRIPTION
The packaging tool 4.1.0 contains the latest feature set.
It sparks the start of independent versioning from the platform.
This allows us to focus on 1 version of the tool, instead of having to maintain multiple versions for different platform versions.
It simplifies decisions for customers, since the latest version of the tool creates packages that work on the newest platform version and older ones.