### PR TITLE
Users/ifolo/localized activity values

### DIFF
--- a/ActivitySettings/ActivitySettings.csproj
+++ b/ActivitySettings/ActivitySettings.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <EnableDynamicLoading>true</EnableDynamicLoading>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.Annotations" />

--- a/ActivitySettings/activityPackage.json
+++ b/ActivitySettings/activityPackage.json
@@ -12,13 +12,36 @@
       "Color": "#FFFFFF",
       "Version": null,
       "DisableOldVersions": false,
-      "EntryPoint": null,
+      "EntryPoint": "ActivitySettings.ExternalActivitySample",
       "HelpPath": null,
       "ConfigPath": "..\\ActivityWebConfig",
       "ConfigURL": null,
+      "MinimalPlatformVersion": "4.0",
       "LocalizedResources": {
         "de": {
           "Description": "Demo für Aktivitätseinstellungen mit externem Dialog."
+        }
+      }
+    },
+    {
+      "AssemblyPath": "..\\_build\\ActivitySettings\\net8.0\\ActivitySettings.dll",
+      "IsExternal": false,
+      "ActivityTypeGuid": "04E3444F-54CC-48AD-8B28-C849BAED9861",
+      "IsFolder": true,
+      "Name": "AllSupportedInputs",
+      "Description": "A demo external activity that shows all the input types one can use in the activity settings and a showcase on how to configure them.",
+      "Vendor": "Skilja GmbH",
+      "Color": "#FFFFFF",
+      "Version": null,
+      "DisableOldVersions": false,
+      "EntryPoint": "ActivitySettings.ExternalActivityWithAllConfiguationSettings",
+      "HelpPath": null,
+      "ConfigPath": null,
+      "ConfigURL": null,
+      "MinimalPlatformVersion": "4.0",
+      "LocalizedResources": {
+        "de": {
+          "Description": "Eine Demo-Externe Aktivität, die alle Eingabetypen zeigt, die man in den Aktivitätseinstellungen verwenden kann, sowie eine Übersicht darüber, wie man sie konfiguriert."
         }
       }
     }

--- a/ActivitySettings/activityPackageLegacy.json
+++ b/ActivitySettings/activityPackageLegacy.json
@@ -1,0 +1,26 @@
+{
+  "PackageName": "Demo Activity With External Dialog",
+  "Packages": [
+    {
+      "AssemblyPath": "..\\_build\\ActivitySettings\\netstandard2.0\\ActivitySettings.dll",
+      "IsExternal": false,
+      "ActivityTypeGuid": "2ADF71C7-E793-4681-8EFC-AC7A6C4380D0",
+      "IsFolder": true,
+      "Name": "ActivitySettings",
+      "Description": "Demo for activity settings with external dialog.",
+      "Vendor": "Skilja GmbH",
+      "Color": "#FFFFFF",
+      "Version": null,
+      "DisableOldVersions": false,
+      "EntryPoint": "ActivitySettings.ExternalActivitySample",
+      "HelpPath": null,
+      "ConfigPath": "..\\ActivityWebConfig",
+      "ConfigURL": null,
+      "LocalizedResources": {
+        "de": {
+          "Description": "Demo für Aktivitätseinstellungen mit externem Dialog."
+        }
+      }
+    }
+  ]
+}

--- a/SampleActivity/Properties/Resources.Designer.cs
+++ b/SampleActivity/Properties/Resources.Designer.cs
@@ -484,6 +484,150 @@ namespace SampleActivity.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This field demonstrates how to set a default value via the settings class constructor..
+        /// </summary>
+        public static string Localizer_DescFromCtor_Description {
+            get {
+                return ResourceManager.GetString("Localizer_DescFromCtor_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Constructor Value.
+        /// </summary>
+        public static string Localizer_DescFromCtor_Name {
+            get {
+                return ResourceManager.GetString("Localizer_DescFromCtor_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This value is set in the settings class constructor..
+        /// </summary>
+        public static string Localizer_DescFromCtor_Prompt {
+            get {
+                return ResourceManager.GetString("Localizer_DescFromCtor_Prompt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This field demonstrates how a developer can set a field’s default value in the activity’s Initialize method..
+        /// </summary>
+        public static string Localizer_DescFromInit_Description {
+            get {
+                return ResourceManager.GetString("Localizer_DescFromInit_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Initialize Value.
+        /// </summary>
+        public static string Localizer_DescFromInit_Name {
+            get {
+                return ResourceManager.GetString("Localizer_DescFromInit_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This value is set in the activity’s Initialize() method..
+        /// </summary>
+        public static string Localizer_DescFromInit_Prompt {
+            get {
+                return ResourceManager.GetString("Localizer_DescFromInit_Prompt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This field demonstrates how to set a default value by assigning it inline in the property definition..
+        /// </summary>
+        public static string Localizer_DescFromInLine_Description {
+            get {
+                return ResourceManager.GetString("Localizer_DescFromInLine_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inline Value.
+        /// </summary>
+        public static string Localizer_DescFromInLine_Name {
+            get {
+                return ResourceManager.GetString("Localizer_DescFromInLine_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This value is set by assigning the property value inline..
+        /// </summary>
+        public static string Localizer_DescFromInLine_Prompt {
+            get {
+                return ResourceManager.GetString("Localizer_DescFromInLine_Prompt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This field demonstrates how to properly use the Prompt attribute to create read-only descriptions that respect UI language switching..
+        /// </summary>
+        public static string Localizer_DescFromPrompt_Description {
+            get {
+                return ResourceManager.GetString("Localizer_DescFromPrompt_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prompt Value.
+        /// </summary>
+        public static string Localizer_DescFromPrompt_Name {
+            get {
+                return ResourceManager.GetString("Localizer_DescFromPrompt_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This value is set via the Prompt attribute and respects UI language switching..
+        /// </summary>
+        public static string Localizer_DescFromPrompt_Prompt {
+            get {
+                return ResourceManager.GetString("Localizer_DescFromPrompt_Prompt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This field demonstrates a common mistake where the Prompt attribute is defined but its value is overridden in the constructor..
+        /// </summary>
+        public static string Localizer_PromptOverride_Description {
+            get {
+                return ResourceManager.GetString("Localizer_PromptOverride_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prompt Override.
+        /// </summary>
+        public static string Localizer_PromptOverride_Name {
+            get {
+                return ResourceManager.GetString("Localizer_PromptOverride_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This value should not be seen as it is overridden in the constructor..
+        /// </summary>
+        public static string Localizer_PromptOverride_Prompt {
+            get {
+                return ResourceManager.GetString("Localizer_PromptOverride_Prompt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This value comes from the constructor and overrides the value defined in the Prompt attribute..
+        /// </summary>
+        public static string Localizer_PromptOverride_PromptOverride {
+            get {
+                return ResourceManager.GetString("Localizer_PromptOverride_PromptOverride", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Number of days the work item must be in the overdue SLA status in order to be counted for notification..
         /// </summary>
         public static string OverdueAgentSettings_DaysOverdue_Description {

--- a/SampleActivity/Properties/Resources.de.resx
+++ b/SampleActivity/Properties/Resources.de.resx
@@ -258,6 +258,54 @@
   <data name="ImportSettings_TiffFilter_Name" xml:space="preserve">
     <value>Tiff Filetr</value>
   </data>
+  <data name="Localizer_DescFromCtor_Description" xml:space="preserve">
+    <value>Dieses Feld zeigt, wie ein Standardwert über den Konstruktor der Einstellungs-Klasse gesetzt wird.</value>
+  </data>
+  <data name="Localizer_DescFromCtor_Name" xml:space="preserve">
+    <value>Konstruktorwert</value>
+  </data>
+  <data name="Localizer_DescFromCtor_Prompt" xml:space="preserve">
+    <value>Dieser Wert wird im Konstruktor der Einstellungs-Klasse gesetzt.</value>
+  </data>
+  <data name="Localizer_DescFromInit_Description" xml:space="preserve">
+    <value>Dieses Feld zeigt, wie ein Entwickler den Standardwert eines Feldes in der Initialize-Methode der Aktivität setzen kann.</value>
+  </data>
+  <data name="Localizer_DescFromInit_Name" xml:space="preserve">
+    <value>Initialisierungswert</value>
+  </data>
+  <data name="Localizer_DescFromInit_Prompt" xml:space="preserve">
+    <value>Dieser Wert wird in der Initialize()-Methode der Aktivität gesetzt.</value>
+  </data>
+  <data name="Localizer_DescFromInLine_Description" xml:space="preserve">
+    <value>Dieses Feld zeigt, wie ein Standardwert direkt in der Eigenschaftsdefinition zugewiesen wird.</value>
+  </data>
+  <data name="Localizer_DescFromInLine_Name" xml:space="preserve">
+    <value>Inline-Wert</value>
+  </data>
+  <data name="Localizer_DescFromInLine_Prompt" xml:space="preserve">
+    <value>Dieser Wert wird direkt in der Eigenschaftsdefinition zugewiesen.</value>
+  </data>
+  <data name="Localizer_DescFromPrompt_Description" xml:space="preserve">
+    <value>Dieses Feld zeigt, wie das Prompt-Attribut richtig verwendet wird, um schreibgeschützte Beschreibungen zu erstellen, die die Sprachumschaltung der Benutzeroberfläche berücksichtigen.</value>
+  </data>
+  <data name="Localizer_DescFromPrompt_Name" xml:space="preserve">
+    <value>Prompt-Wert</value>
+  </data>
+  <data name="Localizer_DescFromPrompt_Prompt" xml:space="preserve">
+    <value>Dieser Wert wird über das Prompt-Attribut gesetzt und berücksichtigt die Sprachumschaltung der Benutzeroberfläche.</value>
+  </data>
+  <data name="Localizer_PromptOverride_Description" xml:space="preserve">
+    <value>Dieses Feld zeigt einen häufigen Fehler, bei dem das Prompt-Attribut definiert ist, sein Wert jedoch im Konstruktor überschrieben wird.</value>
+  </data>
+  <data name="Localizer_PromptOverride_Name" xml:space="preserve">
+    <value>Überschriebener Prompt</value>
+  </data>
+  <data name="Localizer_PromptOverride_Prompt" xml:space="preserve">
+    <value>Dieser Wert sollte nicht sichtbar sein, da er im Konstruktor überschrieben wird.</value>
+  </data>
+  <data name="Localizer_PromptOverride_PromptOverride" xml:space="preserve">
+    <value>Dieser Wert stammt aus dem Konstruktor und überschreibt den im Prompt-Attribut definierten Wert.</value>
+  </data>
   <data name="OverdueAgentSettings_DaysOverdue_Description" xml:space="preserve">
     <value>Anzahl der Tage, die das Workitem im überfälligen SLA-Status sein muß, um für die Benachrichtigung gezählt zu werden.</value>
   </data>

--- a/SampleActivity/Properties/Resources.resx
+++ b/SampleActivity/Properties/Resources.resx
@@ -373,4 +373,52 @@ With every tick it counts the number of work items that have the SLA status in O
   <data name="ConfigurationValidationSettings_Validations_NoDocumentType" xml:space="preserve">
     <value>This activity expects has configured a document type to be used, but there are no document types assigned to the process</value>
   </data>
+  <data name="Localizer_DescFromCtor_Description" xml:space="preserve">
+    <value>This field demonstrates how to set a default value via the settings class constructor.</value>
+  </data>
+  <data name="Localizer_DescFromCtor_Name" xml:space="preserve">
+    <value>Constructor Value</value>
+  </data>
+  <data name="Localizer_DescFromCtor_Prompt" xml:space="preserve">
+    <value>This value is set in the settings class constructor.</value>
+  </data>
+  <data name="Localizer_DescFromInit_Description" xml:space="preserve">
+    <value>This field demonstrates how a developer can set a field’s default value in the activity’s Initialize method.</value>
+  </data>
+  <data name="Localizer_DescFromInit_Name" xml:space="preserve">
+    <value>Initialize Value</value>
+  </data>
+  <data name="Localizer_DescFromInit_Prompt" xml:space="preserve">
+    <value>This value is set in the activity’s Initialize() method.</value>
+  </data>
+  <data name="Localizer_DescFromInLine_Description" xml:space="preserve">
+    <value>This field demonstrates how to set a default value by assigning it inline in the property definition.</value>
+  </data>
+  <data name="Localizer_DescFromInLine_Name" xml:space="preserve">
+    <value>Inline Value</value>
+  </data>
+  <data name="Localizer_DescFromInLine_Prompt" xml:space="preserve">
+    <value>This value is set by assigning the property value inline.</value>
+  </data>
+  <data name="Localizer_DescFromPrompt_Description" xml:space="preserve">
+    <value>This field demonstrates how to properly use the Prompt attribute to create read-only descriptions that respect UI language switching.</value>
+  </data>
+  <data name="Localizer_DescFromPrompt_Name" xml:space="preserve">
+    <value>Prompt Value</value>
+  </data>
+  <data name="Localizer_DescFromPrompt_Prompt" xml:space="preserve">
+    <value>This value is set via the Prompt attribute and respects UI language switching.</value>
+  </data>
+  <data name="Localizer_PromptOverride_Description" xml:space="preserve">
+    <value>This field demonstrates a common mistake where the Prompt attribute is defined but its value is overridden in the constructor.</value>
+  </data>
+  <data name="Localizer_PromptOverride_Name" xml:space="preserve">
+    <value>Prompt Override</value>
+  </data>
+  <data name="Localizer_PromptOverride_Prompt" xml:space="preserve">
+    <value>This value should not be seen as it is overridden in the constructor.</value>
+  </data>
+  <data name="Localizer_PromptOverride_PromptOverride" xml:space="preserve">
+    <value>This value comes from the constructor and overrides the value defined in the Prompt attribute.</value>
+  </data>
 </root>

--- a/SampleActivity/README.md
+++ b/SampleActivity/README.md
@@ -1,30 +1,145 @@
-# SampleEventDrivenActivity
+# SampleActivity
 
-This project contains sample implementations for several event driven activities.
-The following samples for event-driven activities are provided to demonstrate how to use the Platform C# API to upload a stream to the platform,
-to create work items, process the work items and return the results when processing is completed.
+This project contains sample implementations for several activities. 
+These samples are C# source code samples that are included to show how to implement time- and document-driven activities. 
+
 The following sample activity types are provided that use the interfaces with settings:
 
-## EDA Initializer Activity
+## SampleTimerImporter
 
-The EDA Initializer sample activity reads the uploaded stream, which provides a ZIP archive, and creates a work item with Document hierarchy based on the folders hierarchy in the uploaded stream.
-For each uploaded ZIP file one work item is created.
-However, the ZIP file can represent a hierarchical document structure so that the work item contains folder and child documents.
-That means the activity implementation needs to know what the uploaded stream is about and what it contains to be able to create the correct document structure for the platform.
+The `SampleTimerImporter` is a timer-driven activity designed to process JPEG and TIFF documents from a specified directory. 
+It scans the directory for files matching the given filters, creates work items for each document, and processes them through the process.
 
-## EDA Notifier Activity
+### Key Features:
+- **Document Importing**: Scans a directory for JPEG and TIFF files based on the specified filters (`JpegFilter` and `TiffFilter`).
+- **Work Item Creation**: For each document, a new work item is created, and the document is added as media.
+- **Custom Values**: Adds routing and filtering values to the work item, customizable based on settings.
 
-When the processing is completed the EDA Notifier sample activity collects the data processed by the platform so that you can give the processed data back to your external system.
-The sample activity shows how to use the platform API to get the data, construct it and to store it as a stream.
-The sample writes a JSON file with field and table values as well as all media and custom extensions that are attached to a work item and stores as a ZIP-stream associated with the work item.
-The EDA notifier activity in a process is configured to send a SignalR notification.
-This notification is shown in the EDA Web Client and EDA Client application, which download and unpack the ZIP-stream so that you can see the results.
 
-## EDA Confirm Activity
+### Settings Class: `ImportSettings`
+- **ImportPath**: Directory where documents are located.
+- **JpegFilter & TiffFilter**: Filters for selecting JPEG and TIFF files.
+- **DocumentType**: Optional document type to initialize for each document.
 
-For processes that contain event-driven activities,
-you can configure any activity within this process to trigger a custom notification either when a work item becomes ready for processing or when a work item has been processed.
-You use notifications to track the progress that means to see in which step of the process the uploaded document is or to notify users about manual intervention,
-for example, to manually correct classification or extraction results.
-The sample given in the EventDrivenConfirm serves as a configuration for an external web-based activity.
-The source code for this web based activity is in the EDAConfirmWeb folder of this repository.
+## SampleDocumentJpgToTiffConverter
+
+The `SampleDocumentJpgToTiffConverter` is a document-driven activity that converts JPEG images to TIFF format. 
+It processes a document containing a JPEG image and converts it to TIFF, appending the converted media back to the document.
+
+### Key Features:
+- **JPEG to TIFF Conversion**: Converts a JPEG image to TIFF format using .NET's `System.Drawing` library.
+- **Document Media Handling**: Identifies the JPEG media in the document, performs the conversion, and appends the new TIFF media.
+- **Custom Media Creation**: Creates new TIFF media from the converted image and appends it to the document for further processing.
+
+## SampleDocumentWaterMarker
+
+The `SampleDocumentWaterMarker` is a document-driven activity that adds a watermark to a processed TIFF document. 
+It processes a document containing a TIFF image, adds a customizable watermark, and saves the modified image back to the document.
+
+### Key Features:
+- **Watermarking**: Adds a watermark text (e.g., "Giulia Demo") to a TIFF image using `System.Drawing` tools.
+- **Media Handling**: Extracts the TIFF media from the document, applies the watermark, and saves the modified image back to the document.
+- **Customizable Watermark Text**: The watermark text is configurable through the `WatermarkText` setting.
+
+### Settings Class: `WatermarkSettings`
+- **WatermarkText**: The text to be displayed as the watermark on the image.
+
+## SampleExporter
+
+The `SampleExporter` is a document-driven activity that stores the document files referred by the work item in a specified export folder. 
+It supports exporting different media types (e.g., PDF, TIFF, JPEG) and can organize the exported files in either a flat structure or nested based on work item ID.
+
+### Key Features:
+- **Exporting Media**: Exports media files from the document according to the specified media type mappings (e.g., "PDF", "Tiff", "Jpg").
+- **Customizable Export Path**: Allows for both flat and nested export paths, with a configurable `ExportPath`.
+- **Recursive Export**: Supports exporting media from child documents in the document hierarchy.
+
+### Settings Class: `ExportSettings`
+- **ExportPath**: The path where exported files will be stored.
+- **ExportMediaMappings**: A dictionary for mapping media types (e.g., "PDF") to their corresponding file extensions (e.g., ".pdf").
+- **FlatExport**: A flag to determine if the export should be flat (i.e., all files in the same folder) or nested (i.e., following the document structure).
+
+
+## SampleOverdueNotifier
+
+The `SampleOverdueNotifier` is a system agent that identifies work items that are either overdue or in warning status and sends an email notification if any are found. 
+This agent is configured to check work items based on a specified overdue duration and can optionally include work items that are close to overdue.
+
+### Key Features:
+- **Identifying Overdue Work Items**: Filters work items based on their `SLAStatus` and compares their expiration or warning date with the current date.
+- **Email Notification**: Sends an email with the number of overdue work items to a specified recipient, based on configurable SMTP server settings.
+- **Configurable Settings**: Allows configuration of the number of days a work item can be overdue before triggering the email and whether to include items that are close to overdue.
+
+### Settings Class: `OverdueAgentSettings`
+- **DaysOverdue**: The number of days a work item must be overdue to trigger a notification.
+- **IncludeCloseTo**: A flag to include work items that are close to being overdue (in "Warning" status).
+- **SendTo**: The recipient name for the email notification.
+- **SendToMail**: The recipient email address for the notification.
+- **ServerSettings**: SMTP configuration settings for sending the email, including server address, port, username, and password.
+- **ReadMe**: A read-only text field that provides additional guidance (optional).
+
+### Settings Class: `SmtpSettings`
+- **ServerAddress**: The address of the SMTP server to be used for sending emails.
+- **ServerPort**: The port number for the SMTP server.
+- **UseSSL**: A flag to determine if SSL should be used for the email transmission.
+- **UserName**: The username for authenticating with the SMTP server.
+- **From**: The sender's email address (optional).
+- **Password**: The password for the SMTP server authentication.
+
+## SampleConfigurationValidator
+
+The `SampleConfigurationValidator` demonstrates configuration validation within an activity. 
+It is designed to check if the configuration settings are correct and meets the required conditions before being applied to an actual process.
+
+### Key Features:
+- **File Path Validation**: Ensures the configured file path exists. If the file is missing, a warning or error is generated depending on whether the environment is a design-time or runtime.
+- **Required Field Check**: If the `IfThisIsTrue` setting is enabled, the `ThisMustNotBeEmpty` field is validated to ensure it is not empty.
+- **Date Validation**: Verifies that `ThisMustBeInThePast` is a date in the past and `ThisMustBeInTheFuture` is a date in the future.
+- **Document Type Validation**: Ensures that the configured document type is assigned to the process, and checks for duplicate column names across tables in the document type.
+
+### Settings Class: `ConfigurationValidationSettings`
+- **FilePath**: Specifies a file path that must exist for the configuration to be valid.
+- **IfThisIsTrue**: A boolean that, if true, requires the `ThisMustNotBeEmpty` field to be populated.
+- **ThisMustNotBeEmpty**: A text field that must be non-empty if `IfThisIsTrue` is true.
+- **ThisMustBeInThePast**: A date field that must be in the past.
+- **ThisMustBeInTheFuture**: A date field that must be in the future.
+- **DocumentType**: A string field that must match an existing document type assigned to the process.
+
+### Validation Logic:
+- The validation results are collected in a list of `DtoActivityConfigurationValidationResult` objects, with various levels of severity:
+  - **Error**: Serious issues that prevent configuration from being used.
+  - **Warning**: Potential problems that should be addressed but do not prevent configuration.
+  - **Info**: Informational messages, such as duplicate columns in document types.
+
+### Validation Process:
+1. **File Path Check**: If the specified file path does not exist, it adds an error or info message based on whether it's design-time or runtime.
+2. **Required Field Check**: If the `IfThisIsTrue` flag is enabled, the `ThisMustNotBeEmpty` field must not be empty. If it is, an error message is added.
+3. **Date Validations**: Ensures `ThisMustBeInThePast` is a past date and `ThisMustBeInTheFuture` is a future date. Warnings are issued if they are not valid.
+4. **Document Type Validation**: If a document type is specified, it checks that the document type is assigned to the process and raises an error if it is not. Additionally, it checks for any duplicate columns within the document type and issues info messages accordingly.
+
+### Activity Class: `SampleConfigurationValidator`
+- This activity doesn't perform any actual work. It's primarily used for configuration validation, ensuring that all necessary conditions are met before execution.
+
+## SampleAppSettings
+
+The `SampleAppSettings` activity retrieves specific application settings and outputs them into a document under a custom value. 
+It allows the configuration of which settings to retrieve and the custom value key under which the output is stored.
+
+### Key Features:
+- **Retrieve Application Settings**: Fetches application settings specified in the `AppSettingsToOutput` list.
+- **Custom Value Output**: Outputs the retrieved settings to the document under a configurable custom value.
+- **Configurable Settings**: Allows configuration of the settings to output and the custom key for the result.
+
+### Settings Class: `AppSettingsSettings`
+- **AppSettingsToOutput**: A comma-separated list of application setting names to retrieve.
+- **OutputCustomValue**: The custom key to store the concatenated settings values in the document.
+
+## Localization of Activity Settings
+
+All of the settings used in the sample activities are fully localized, showcasing how to implement localization in activity settings. By leveraging resource files, each setting can be displayed in different languages based on the current culture of the system.
+
+### Key Features:
+- **Localized Display Names and Descriptions**: The `DisplayName` and `Description` attributes for each setting are dynamically localized using resource files. This allows different languages to be supported easily.
+- **ResourceType**: The settings utilize a `ResourceType` attribute pointing to a `Resources` file, which contains the translations for the setting names and descriptions.
+- **Seamless Integration with Localization**: This approach can be used as a showcase on how to configure and manage activity settings that require translation, making it easy to create multilingual experiences.
+

--- a/SampleActivity/README.md
+++ b/SampleActivity/README.md
@@ -134,6 +134,30 @@ It allows the configuration of which settings to retrieve and the custom value k
 - **AppSettingsToOutput**: A comma-separated list of application setting names to retrieve.
 - **OutputCustomValue**: The custom key to store the concatenated settings values in the document.
 
+## SampleLocalizationDefaults
+
+The `SampleLocalizationDefaults` is a external activity that demonstrates how to properly set default values for localized fields in an activity. 
+It showcases different approaches for setting default values and highlights how these values interact with UI language switching.
+
+### Key Features:
+- **Default Value Initialization**: Demonstrates how to set default values in the `Initialize` method.
+- **Localization Awareness**: Ensures that the assigned default values align with the UI culture at the time of activity initialization.
+- **Showcase of Common Mistakes**: Highlights potential pitfalls when setting default values for localized fields.
+
+### Settings Class: `Localizer`
+- **DescFromPrompt**: A properly localized read-only text field using the `Prompt` attribute.
+- **PromptOverride**: A field demonstrating the incorrect practice of overriding the `Prompt` attribute in the constructor.
+- **DescFromCtor**: A field that sets a default value in the constructor, storing it as a constant.
+- **DescFromInLine**: A field where the default value is set inline within the property definition.
+- **DescFromInit**: A field demonstrating how default values can be assigned in the `Initialize` method.
+
+### Implementation Notes:
+- The `Initialize` method assigns a localized default value to `DescFromInit`, ensuring that it respects the UI culture at the time of registration.
+- Once set, these values do not automatically update with UI language switching unless reset in the activity editor.
+
+This sample serves as a reference for properly handling value localization in activity settings.
+
+
 ## Localization of Activity Settings
 
 All of the settings used in the sample activities are fully localized, showcasing how to implement localization in activity settings. By leveraging resource files, each setting can be displayed in different languages based on the current culture of the system.

--- a/SampleActivity/SampleAppSettings.cs
+++ b/SampleActivity/SampleAppSettings.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using SampleActivity.Settings;
+﻿using SampleActivity.Settings;
 using STG.Common.DTO;
+using STG.Common.Utilities.Settings;
 using STG.RT.API.Activity;
 using STG.RT.API.Document;
-using STG.Common.Utilities.Settings;
 
 namespace SampleActivity
 {

--- a/SampleActivity/SampleLocalizationDefaults.cs
+++ b/SampleActivity/SampleLocalizationDefaults.cs
@@ -1,0 +1,20 @@
+﻿using SampleActivity.Configuration;
+using SampleActivity.Properties;
+using STG.RT.API.Activity;
+using System.IO;
+
+namespace SampleActivity
+{
+    public class SampleLocalizationDefaults : STGExternalAbstract<Localizer>
+    {
+        /// <summary>
+        /// Demonstrates how to set the default value in the Initialize method
+        /// </summary>
+        /// <param name="configuration"></param>
+        public override void Initialize(Stream configuration)
+        {
+            base.Initialize(configuration);
+            ActivityConfiguration.DescFromInit = Resources.Localizer_DescFromInit_Prompt;
+        }
+    }
+}

--- a/SampleActivity/Settings/ConfigurationValidationSettings.cs
+++ b/SampleActivity/Settings/ConfigurationValidationSettings.cs
@@ -93,7 +93,7 @@ namespace SampleActivity.Settings
 
             if (!string.IsNullOrWhiteSpace(DocumentType)) //Document type is set; let us check if document type with the matching name is assigned to process
             {
-                if (options.DocumentTypes != null || options.DocumentTypes.Count == 0)  //No document types assigned to process; warn
+                if (options.DocumentTypes == null || options.DocumentTypes.Count == 0)  //No document types assigned to process; warn
                 {
                     ret.Add(new DtoActivityConfigurationValidationResult()
                     {

--- a/SampleActivity/Settings/Localizer.cs
+++ b/SampleActivity/Settings/Localizer.cs
@@ -1,0 +1,78 @@
+﻿using SampleActivity.Properties;
+using STG.Common.DTO.Metadata;
+using STG.RT.API.Activity;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using STG.Common.Utilities.Activities;
+
+namespace SampleActivity.Configuration
+{
+    /// <summary>
+    /// This activity demonstrates how to localize values in activity settings and how they respect (or do not respect) UI language switching.
+    /// </summary>
+    public class Localizer : ActivityConfigBase<Localizer>
+    {
+        /// <summary>
+        /// The proper way to set a localized value for a read-only text field.
+        /// When the value is set in the <see cref="DisplayAttribute.Prompt"/> attribute, the activity does not store the value.
+        /// Instead, the UI generates it based on the value from the Prompt attribute.
+        /// This approach ensures that the value respects the UI culture and updates dynamically when the UI language switches.
+        /// </summary>
+        [Display(Name = nameof(Resources.Localizer_DescFromPrompt_Name), Description = nameof(Resources.Localizer_DescFromPrompt_Description), Prompt = nameof(Resources.Localizer_DescFromPrompt_Prompt), ResourceType = typeof(Resources))]
+        [InputType(InputType.textarea), ReadOnly(true)]
+        public string DescFromPrompt { get; set; }
+
+        /// <summary>
+        /// A common mistake: overriding a value set in the <see cref="DisplayAttribute.Prompt"/> attribute within the constructor (or activity initialization method).
+        /// When overridden, the constructor-assigned value takes precedence over the Prompt attribute.
+        /// Although the value is still taken from resources, it respects the UI culture only at the moment of activity registration.
+        /// The overridden value is stored as a constant in the settings and does not change when the UI language switches.
+        /// To reset it to the correct localized value, one must manually reset the default activity settings in the editor.
+        /// Resetting activity settings restores the value based on the UI culture at the time of the reset.
+        /// </summary>
+        [Display(Name = nameof(Resources.Localizer_PromptOverride_Name), Description = nameof(Resources.Localizer_PromptOverride_Description), Prompt = nameof(Resources.Localizer_PromptOverride_Prompt), ResourceType = typeof(Resources))]
+        [InputType(InputType.textarea), ReadOnly(true)]
+        public string PromptOverride { get; set; }
+
+        /// <summary>
+        /// Read-only values can be defined without using the Prompt attribute.
+        /// Instead, their value can be set in the constructor, as demonstrated here.
+        /// The constructor-assigned value is still retrieved from resources and respects the UI culture only at the moment of activity registration.
+        /// However, it is then stored in the settings as a constant.
+        /// Once stored, the value does not change when the UI language switches.
+        /// To update it, one must manually reset the default activity settings in the editor.
+        /// Resetting activity settings restores the property value based on the UI culture at the time of the reset.
+        /// </summary>
+        [Display(Name = nameof(Resources.Localizer_DescFromCtor_Name), Description = nameof(Resources.Localizer_DescFromCtor_Description), ResourceType = typeof(Resources))]
+        [InputType(InputType.textarea), ReadOnly(true)]
+        public string DescFromCtor { get; set; }
+
+        /// <summary>
+        /// Similar to <see cref="DescFromCtor"/>, but assigns the default value inline.
+        /// The value is still retrieved from resources and respects the UI culture only at the moment of activity registration.
+        /// However, it is stored as a constant in the settings and does not change when the UI language switches.
+        /// To update it, one must manually reset the default activity settings in the editor.
+        /// Resetting activity settings restores the property value based on the UI culture at the time of the reset.
+        /// </summary>
+        [Display(Name = nameof(Resources.Localizer_DescFromInLine_Name), Description = nameof(Resources.Localizer_DescFromInLine_Description), ResourceType = typeof(Resources))]
+        [InputType(InputType.textarea), ReadOnly(true)]
+        public string DescFromInLine { get; set; } = Resources.Localizer_DescFromInLine_Prompt;
+
+        /// <summary>
+        /// Default values for properties can also be set in the override of the <see cref="ActivityConfigLoader{TActivityConfig}.Initialize(System.IO.Stream)"/> method of the activity.
+        /// This allows developers to define different default values based on configured activity settings.
+        /// Like <see cref="DescFromInLine"/> and <see cref="DescFromCtor"/>, the value is retrieved from resources and respects the UI culture only at the moment of activity registration.
+        /// Once set, the value is stored as a constant in the settings and does not change when the UI language switches.
+        /// </summary>
+        [Display(Name = nameof(Resources.Localizer_DescFromInit_Name), Description = nameof(Resources.Localizer_DescFromInit_Description), ResourceType = typeof(Resources))]
+        [InputType(InputType.textarea), ReadOnly(true)]
+        public string DescFromInit { get; set; }
+
+        public Localizer()
+        {
+            DescFromCtor = Resources.Localizer_DescFromCtor_Prompt;
+            PromptOverride = Resources.Localizer_PromptOverride_PromptOverride;
+        }
+    }
+
+}

--- a/SampleActivity/activityPackage.json
+++ b/SampleActivity/activityPackage.json
@@ -161,6 +161,28 @@
           "Description": "Zeigt, wie man eine zeitgesteuerte Aktivität erstellt, die ein Wasserzeichen auf das Bild setzt."
         }
       }
+    },
+    {
+      "AssemblyPath": "..\\_build\\SampleActivity\\netstandard2.0\\SampleActivity.dll",
+      "IsExternal": false,
+      "ActivityTypeGuid": "C48EF061-106D-47E3-AE02-AF3EC0DE7C42",
+      "IconPath": "icon\\translate.svg",
+      "IsFolder": true,
+      "Name": "Sample Defaults",
+      "Description": "Demonstrates how to set default settings for an activity and how these defaults respect the UI culture.",
+      "Vendor": "Skilja GmbH",
+      "Version": "1.0.0.0",
+      "Color": "#FFFFFF",
+      "DisableOldVersions": false,
+      "EntryPoint": "SampleActivity.SampleLocalizationDefaults",
+      "HelpPath": null,
+      "ConfigPath": null,
+      "ConfigURL": null,
+      "LocalizedResources": {
+        "de": {
+          "Description": "Demonstriert, wie man Standardwerte für eine Aktivität festlegt und wie diese Standardwerte die UI-Kultur berücksichtigen."
+        }
+      }
     }
   ]
 }

--- a/SampleActivity/icon/translate.svg
+++ b/SampleActivity/icon/translate.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 5H9M16 5H13.5M9 5L13.5 5M9 5V3M13.5 5C12.6795 7.73513 10.9612 10.3206 9 12.5929M4 17.5C5.58541 16.1411 7.376 14.4744 9 12.5929M9 12.5929C8 11.5 6.4 9.3 6 8.5M9 12.5929L12 15.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.5 21L14.6429 18M21.5 21L20.3571 18M14.6429 18L17.5 10.5L20.3571 18M14.6429 18H20.3571" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/SampleEventDrivenActivity/README.md
+++ b/SampleEventDrivenActivity/README.md
@@ -1,12 +1,30 @@
-# SampleActivity
+# SampleEventDrivenActivity
 
-This project contains sample implementations for several activities. 
-These samples are C# source code samples that are included to show how to implement time- and document-driven activities. 
-
+This project contains sample implementations for several event driven activities.
+The following samples for event-driven activities are provided to demonstrate how to use the Platform C# API to upload a stream to the platform,
+to create work items, process the work items and return the results when processing is completed.
 The following sample activity types are provided that use the interfaces with settings:
 
-- SampleTimerImporter - a sample for a timer-driven activity that loads JPEG and TIFF documents from a specified import path.
-- SampleDocumentJpgToTiffConverter - a sample for a document-driven activity that converts JPEG documents into TIFF documents.
-- SampleDocumentWaterMarker - a sample for a document-driven activity that adds a watermark to the processed document.
-- SampleExporter - a sample for a document-driven activity that stores the document files referred by the work item in a specified export folder.
-- SampleOverdueNotifier - a sample for a system agent that looks for work items that have the status overdue or warning and sends an email.
+## EDA Initializer Activity
+
+The EDA Initializer sample activity reads the uploaded stream, which provides a ZIP archive, and creates a work item with Document hierarchy based on the folders hierarchy in the uploaded stream.
+For each uploaded ZIP file one work item is created.
+However, the ZIP file can represent a hierarchical document structure so that the work item contains folder and child documents.
+That means the activity implementation needs to know what the uploaded stream is about and what it contains to be able to create the correct document structure for the platform.
+
+## EDA Notifier Activity
+
+When the processing is completed the EDA Notifier sample activity collects the data processed by the platform so that you can give the processed data back to your external system.
+The sample activity shows how to use the platform API to get the data, construct it and to store it as a stream.
+The sample writes a JSON file with field and table values as well as all media and custom extensions that are attached to a work item and stores as a ZIP-stream associated with the work item.
+The EDA notifier activity in a process is configured to send a SignalR notification.
+This notification is shown in the EDA Web Client and EDA Client application, which download and unpack the ZIP-stream so that you can see the results.
+
+## EDA Confirm Activity
+
+For processes that contain event-driven activities,
+you can configure any activity within this process to trigger a custom notification either when a work item becomes ready for processing or when a work item has been processed.
+You use notifications to track the progress that means to see in which step of the process the uploaded document is or to notify users about manual intervention,
+for example, to manually correct classification or extraction results.
+The sample given in the EventDrivenConfirm serves as a configuration for an external web-based activity.
+The source code for this web based activity is in the EDAConfirmWeb folder of this repository.

--- a/all.proj
+++ b/all.proj
@@ -43,10 +43,14 @@
     </PropertyGroup>
     <!-- Package the event driven sample activities -->
     <Exec Command="$(PkgSTG_Tools_ActivityPackaging_Packager) -f &quot;.\SampleEventDrivenActivity\activityPackage.json&quot; -version $(FileVersion) $(PublishOutputDirectory)\DemoActivities\SampleEventDrivenActivity.stgpack" />
+    <!-- Package the the old sample activities showing how to implement localization/validation-->
+    <Exec Command="$(PkgSTG_Tools_ActivityPackaging_Packager) -f &quot;.\SampleActivity\activityPackage.json&quot; -version $(FileVersion) $(PublishOutputDirectory)\DemoActivities\LocalizedActivities.stgpack" />
     <!-- Package sample activities that show-case licensing as well as splitting/merging -->
     <Exec Command="$(PkgSTG_Tools_ActivityPackaging_Packager) -f &quot;.\SampleActivities\activityPackage.json&quot; -version $(FileVersion) $(PublishOutputDirectory)\DemoActivities\SampleActivities.stgpack" />
     <!-- Sample demonstrating how to package .NET Framework and .NET8 compatible activity packages -->
     <Exec Command="$(PkgSTG_Tools_ActivityPackaging_Packager) -f &quot;.\SampleActivities\backwardsCompatibility.json&quot; -version $(FileVersion) $(PublishOutputDirectory)\DemoActivities\BackwardsCompatibilitySample.stgpack" />
+    <!-- Sample external activities -->
+    <Exec Command="$(PkgSTG_Tools_ActivityPackaging_Packager) -f &quot;.\ActivitySettings\activityPackage.json&quot; -version $(FileVersion) $(PublishOutputDirectory)\DemoActivities\ExternalActivities.stgpack" />
     <Copy SourceFiles=".\SampleActivities\Readme.md" DestinationFiles="$(PublishOutputDirectory)\DemoActivities\SampleActivities_Readme.md" />
     <Copy SourceFiles="@(Package-Tools-and-Websites)" DestinationFolder="$(PublishOutputDirectory)\DemoActivities\%(Package-Tools-and-Websites.Subfolder)\%(RecursiveDir)" />
   </Target>


### PR DESCRIPTION
- The readme files in EventDriven and SampleActivity folders where swapped
- The readme for SampleActivity is extended with detailed description for each activity in the project
- There was a bug in Document type validation logic that was fixed
- There is a new activity in the SampleActivity project that demonstrates how to set default values to activity settings and how the value respects the UI culture
  - The readme is extended to mention this activity as well
  - The Activity is added into bundle
- ActivitySettings are built as netStandard or net8 so they can be imported/tested on new and old platform versions
- Packaging target in all.proj file adjusted to produce more bundles