### PR TITLE
Signal-R methods are now Async so the name follows the convention

### DIFF
--- a/src/EDAWebClient/src/app/components/logs/logs.component.ts
+++ b/src/EDAWebClient/src/app/components/logs/logs.component.ts
@@ -66,11 +66,11 @@ export class LogsComponent implements OnDestroy {
   async reconnect() {
     await this.connection.stop();
     await this.connection.start();
-    this.connection.off('OnEventNotification');
+    this.connection.off('OnEventNotificationAsync');
   }
 
   subscribeOnProcessActivity(processId: number) {
-    this.connection.on('OnEventNotification', (data: ResultNotificationItem) => {
+    this.connection.on('OnEventNotificationAsync', (data: ResultNotificationItem) => {
       this.logsList.unshift(data.Message);
     })
     
@@ -85,11 +85,11 @@ export class LogsComponent implements OnDestroy {
   }
 
   joinGroup() {
-    this.connection.invoke('JoinGroup', this.connectedGroup);
+    this.connection.invoke('JoinGroupAsync', this.connectedGroup);
   }
 
   leaveGroup() {
-    this.connection.invoke('LeaveGroup', this.connectedGroup);
+    this.connection.invoke('LeaveGroupAsync', this.connectedGroup);
   }
 
   ngOnDestroy() {

--- a/src/EDAWebClient/src/app/services/auth.service.ts
+++ b/src/EDAWebClient/src/app/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { ConfigService } from './utils/config.service';
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { BehaviorSubject } from 'rxjs';
 import { StorageService } from './utils/storage.service';
 import { UserDataType} from '../models/auth.model';
 import {ActivityService} from './activity.service';


### PR DESCRIPTION
Since upgrade to Signal-R Core on server side all the hub methods are Async.
Server side follows the Naming Convention, but calls to the hub in the client where  not properly upgraded, so client did not receive any notifications

Import of behavior subject in auth service fixes issue that caused app build in production not to bootstrap properly