### PR TITLE
adjusted build to use new node package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Node.js.redist" Version="24.14.1" />
+    <PackageVersion Include="Node.js.redist.win" Version="24.14.1" />
     <PackageVersion Include="NuGet.CommandLine" Version="6.10.1" />
     <PackageVersion Include="NUnit" Version="4.2.2" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.4.0" />

--- a/all.proj
+++ b/all.proj
@@ -4,7 +4,7 @@
   <ItemGroup>
     <PackageReference Include="STG.Tools.ActivityPackaging" />
     <PackageReference Include="NuGet.CommandLine" />
-    <PackageReference Include="Node.js.redist" />
+    <PackageReference Include="Node.js.redist.win" />
   </ItemGroup>
   <ItemGroup>
     <Package-Tools-and-Websites Include="$(BuildOutputDirectory)/EDAClient/net8.0-windows/*;" Exclude="">
@@ -58,9 +58,9 @@
   </Target>
   <Target Name="build-websites">
     <PropertyGroup>
-      <nodePath>$(PkgNode_js_redist)\tools\win-x64\</nodePath>
+      <nodePath>$(PkgNode_js_redist_win)\tools\x64\</nodePath>
       <nodeExe>$(nodePath)node.exe</nodeExe>
-      <npmPath>$(PkgNode_js_redist)\tools\win-x64\package\bin</npmPath>
+      <npmPath>$(PkgNode_js_redist_win)\tools\x64\package\bin</npmPath>
     </PropertyGroup>
 
     <MSBuild Condition="!Exists('$(npmPath)')" Targets="installNPM" Properties="nodeExe=$(nodeExe)" Projects="$(MSBuildThisFileFullPath)" />
@@ -73,7 +73,7 @@
     <Exec WorkingDirectory="./src/EDAWebClient" Command="
         set PATH=%PATH:C:\Program Files\nodejs=%
         set path=%PATH%;$(nodePath)
-        &quot;$(nodeExe)&quot; &quot;$(npmPath)\npm-cli.js&quot; run ng build -- --prod --base-href ." />
+        &quot;$(nodeExe)&quot; &quot;$(npmPath)\npm-cli.js&quot; run ng build -- --configuration production --base-href ." />
 
     <Exec WorkingDirectory="./src/EDAConfirmWeb" Command="
 		set PATH=%PATH:C:\Program Files\nodejs=%
@@ -82,18 +82,18 @@
     <Exec WorkingDirectory="./src/EDAConfirmWeb" Command="
         set PATH=%PATH:C:\Program Files\nodejs=%
         set path=%PATH%;$(nodePath)
-        &quot;$(nodeExe)&quot; &quot;$(npmPath)\npm-cli.js&quot; run ng build -- --prod --base-href ." />
+        &quot;$(nodeExe)&quot; &quot;$(npmPath)\npm-cli.js&quot; run ng build -- --configuration production --base-href ." />
 
     <!-- Disabled untill upper two are upgraded to newer version -->
-    <!--<Exec WorkingDirectory="./WorkItemSearchAndLock"  Command="&quot;$(nodeExe)&quot; &quot;$(npmPath)\npm-cli.js&quot; install" />-->
-    <!--<Exec WorkingDirectory="./WorkItemSearchAndLock"  Command=" 
+    <Exec WorkingDirectory="./src/WorkItemSearchAndLock"  Command="&quot;$(nodeExe)&quot; &quot;$(npmPath)\npm-cli.js&quot; install" />
+    <Exec WorkingDirectory="./src/WorkItemSearchAndLock"  Command=" 
         set PATH=%PATH:C:\Program Files\nodejs=%
         set path=%PATH%;$(nodePath)
-        &quot;$(nodeExe)&quot; &quot;$(npmPath)\npm-cli.js&quot; run ng build " />-->
+        &quot;$(nodeExe)&quot; &quot;$(npmPath)\npm-cli.js&quot; run ng build -- --configuration production --base-href ." />
   </Target>
   <Target Name="installNPM">
-    <Copy SourceFiles="NPM_install.js" DestinationFolder="$(PkgNode_js_redist)\tools\win-x64" />
-    <Exec WorkingDirectory="$(PkgNode_js_redist)\tools\win-x64" Command="&quot;$(nodeExe)&quot; NPM_install.js 24.14.1" />
+    <Copy SourceFiles="NPM_install.js" DestinationFolder="$(PkgNode_js_redist_win)\tools\x64" />
+    <Exec WorkingDirectory="$(PkgNode_js_redist_win)\tools\x64" Command="&quot;$(nodeExe)&quot; NPM_install.js 11.11.0" />
   </Target>
 
 </Project>

--- a/src/EDAWebClient/package-lock.json
+++ b/src/EDAWebClient/package-lock.json
@@ -16,7 +16,6 @@
         "@angular/forms": "^21.2.18",
         "@angular/material": "^21.2.14",
         "@angular/platform-browser": "^21.2.18",
-        "@angular/platform-browser-dynamic": "^21.2.18",
         "@angular/router": "^21.2.18",
         "@microsoft/signalr": "^10.0.0",
         "angular-auth-oidc-client": "^21.0.1",
@@ -645,25 +644,6 @@
         "@angular/animations": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@angular/platform-browser-dynamic": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.18.tgz",
-      "integrity": "sha512-doTDss6GhDTGjVuuANlzFrdYKBqHQVlWgy2tiTjy9EbrmMTOOHg0D6yUQXh1ZqmUWKDZ3owkUjUNGiXt92rQ6w==",
-      "deprecated": "@angular/platform-browser-dynamic is deprecated. Use `@angular/platform-browser` instead.",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "21.2.18",
-        "@angular/compiler": "21.2.18",
-        "@angular/core": "21.2.18",
-        "@angular/platform-browser": "21.2.18"
       }
     },
     "node_modules/@angular/router": {


### PR DESCRIPTION
- adjusted package reference and package variables to match new redist for windows
- using new --configuration production instead of old and removed --prod
- re.enabled WorkItemSearchAndLock in build